### PR TITLE
Add missing argument to feature generator in the pretrain scripts

### DIFF
--- a/pretrain_inception_resnet.py
+++ b/pretrain_inception_resnet.py
@@ -84,5 +84,5 @@ VAL_RECORD_PATH = 'weights/inception_resnet_val.tfrecord'
 model.fit_generator(features_generator(TRAIN_RECORD_PATH, NUM_FEATURES, batchsize=batchsize, shuffle=True),
                     steps_per_epoch=(500000. // batchsize),
                     epochs=epochs, verbose=1, callbacks=callbacks,
-                    validation_data=features_generator(VAL_RECORD_PATH, batchsize=batchsize, shuffle=False),
+                    validation_data=features_generator(VAL_RECORD_PATH, NUM_FEATURES, batchsize=batchsize, shuffle=False),
                     validation_steps=(5000. // batchsize))

--- a/pretrain_nasnet_large.py
+++ b/pretrain_nasnet_large.py
@@ -84,5 +84,5 @@ VAL_RECORD_PATH = 'weights/nasnet_large_val.tfrecord'
 model.fit_generator(features_generator(TRAIN_RECORD_PATH, NUM_FEATURES, batchsize=batchsize, shuffle=True),
                     steps_per_epoch=(500000. // batchsize),
                     epochs=epochs, verbose=1, callbacks=callbacks,
-                    validation_data=features_generator(VAL_RECORD_PATH, batchsize=batchsize, shuffle=False),
+                    validation_data=features_generator(VAL_RECORD_PATH, NUM_FEATURES, batchsize=batchsize, shuffle=False),
                     validation_steps=(5000. // batchsize))

--- a/pretrain_nasnet_mobile.py
+++ b/pretrain_nasnet_mobile.py
@@ -84,5 +84,5 @@ VAL_RECORD_PATH = 'weights/nasnet_val.tfrecord'
 model.fit_generator(features_generator(TRAIN_RECORD_PATH, NUM_FEATURES, batchsize=batchsize, shuffle=True),
                     steps_per_epoch=(500000. // batchsize),
                     epochs=epochs, verbose=1, callbacks=callbacks,
-                    validation_data=features_generator(VAL_RECORD_PATH, batchsize=batchsize, shuffle=False),
+                    validation_data=features_generator(VAL_RECORD_PATH, NUM_FEATURES, batchsize=batchsize, shuffle=False),
                     validation_steps=(5000. // batchsize))


### PR DESCRIPTION
The pretrain_*.py scripts crash because the feature generator function is missing the "number of features" argument on the validation data.
Added this argument and ran the scripts to confirm that they run without crashing.